### PR TITLE
Specify the text-decoration of the Open Info icon

### DIFF
--- a/cartridges/sfcc_dev_tools/cartridge/client/default/scss/_toolbar.scss
+++ b/cartridges/sfcc_dev_tools/cartridge/client/default/scss/_toolbar.scss
@@ -148,6 +148,7 @@
             position: absolute;
             right: 40px;
             top: 0;
+            text-decoration: none;
 
             svg {
                 width: 14px;


### PR DESCRIPTION
Overview:

This is to prevent possible underlines on the Open Info icon